### PR TITLE
Use Conda for Installation as a fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,7 @@
+name = "FEniCS"
+uuid = "186dfeec-b415-5c13-8e76-5fbf19f56f9b"
+
+[deps]
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 1.0
-PyCall
-Requires
-ProgressMeter

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,7 +1,7 @@
 using PyCall
 
 	try
-		pyimport("fenics")
+		pyimport_conda("fenics", "fenics", "conda-forge")
 	catch ee
 		typeof(ee) <: PyCall.PyError || rethrow(ee)
 		@warn("""
@@ -13,4 +13,3 @@ using PyCall
 				 """
 		)
 	end
-

--- a/src/FEniCS.jl
+++ b/src/FEniCS.jl
@@ -2,7 +2,8 @@ __precompile__(false)
 module FEniCS
 using PyCall
 using Requires
-@pyimport fenics
+
+fenics = pyimport_conda("fenics", "fenics", "conda-forge")
 
 function __init__()
 	@require PyPlot="d330b81b-6aea-500a-939a-2ce795aea3ee" include("jplot.jl")
@@ -46,7 +47,7 @@ include("jsolve.jl") #this file contains the solver functions/routines
 include("jinterface.jl")
 
 try
-  pyimport("mshr")
+  pyimport_conda("mshr", "mshr", "conda-forge")
   include("fmshr.jl") #this file contains various geometrical objects using the mshr package
 catch ee
  print("mshr has not been included")

--- a/src/fmshr.jl
+++ b/src/fmshr.jl
@@ -1,4 +1,4 @@
-@pyimport mshr
+mshr = pyimport_conda("mshr", "mshr", "conda-forge")
 @fenicsclass Geometry
 
 #functions necessary for creating meshes from geometrical objects.


### PR DESCRIPTION
This seems to be a fairly robust method for installing FEniCS, more so since Anaconda is well integrated with PyCall. There are some outstanding issues with the OpenMPI arguments in the function builder. I will open another PR for those changes. 
