### PR TITLE
add heat equation example

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,11 +8,12 @@ PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-julia = "1"
 PyCall = "1.90"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 
 [targets]
-test = ["Test"]
+test = ["Test", "OrdinaryDiffEq"]

--- a/examples/heat_equation.jl
+++ b/examples/heat_equation.jl
@@ -1,0 +1,49 @@
+"""
+Solve the heat equation ∂ₜu = Δu on [0,1] using OrdinaryDiffEq for time stepping.
+Boundary conditions are such that an analytic solution is given by:
+    sin(2π*x) * exp(-(2*π)^2*t)
+
+This example demonstrates how to solve time dependent PDE's combining `fenics` and `DiffEq`.
+
+"""
+module HeatEquationExample
+
+using Test
+using OrdinaryDiffEq
+using FEniCS
+
+mesh = UnitIntervalMesh(20)
+V = FunctionSpace(mesh,"P",1)
+u_str = "sin(2*pi*x[0]) * exp(-t*pow(2*pi, 2))"
+
+u = interpolate(Expression(u_str, degree=2, pi=Float64(pi), t=0), V)
+
+bc = DirichletBC(V, 0.0, "on_boundary")
+dudt = TrialFunction(V)
+v = TestFunction(V)
+Dudt = FeFunction(V)
+F = dot(dudt, v)*dx + dot(grad(u), grad(v))*dx
+a = lhs(F)
+L = rhs(F)
+p = (u=u, Dudt=Dudt, bc=bc, a=a, L=L)
+
+function f!(dudt_vec, u_vec, p, t)
+    assign(p.u, u_vec)
+    lvsolve(p.a, p.L, p.Dudt, p.bc)
+    copy!(dudt_vec, get_array(p.Dudt))
+end
+
+u0_vec = get_array(u)
+t_final = 0.1
+tspan = (0.0, t_final)
+prob = ODEProblem(f!, u0_vec, tspan, p)
+u_true = interpolate(Expression(u_str, degree=2, pi=Float64(pi), t=t_final), V)
+
+alg = ImplicitEuler(autodiff=false)
+sol = OrdinaryDiffEq.solve(prob, alg)
+
+vec_sol = get_array(p.u)
+vec_true = get_array(u_true)
+@test vec_sol ≈ vec_true rtol=1e-3
+
+end#module

--- a/examples/heat_equation.jl
+++ b/examples/heat_equation.jl
@@ -12,11 +12,12 @@ using Test
 using OrdinaryDiffEq
 using FEniCS
 
-mesh = UnitIntervalMesh(20)
+mesh = UnitIntervalMesh(50)
 V = FunctionSpace(mesh,"P",1)
 u_str = "sin(2*pi*x[0]) * exp(-t*pow(2*pi, 2))"
 
-u = interpolate(Expression(u_str, degree=2, pi=Float64(pi), t=0), V)
+tspan = (0.0, 0.1)
+u = interpolate(Expression(u_str, degree=2, pi=Float64(pi), t=tspan[1]), V)
 
 bc = DirichletBC(V, 0.0, "on_boundary")
 dudt = TrialFunction(V)
@@ -35,15 +36,19 @@ end
 
 u0_vec = get_array(u)
 t_final = 0.1
-tspan = (0.0, t_final)
 prob = ODEProblem(f!, u0_vec, tspan, p)
-u_true = interpolate(Expression(u_str, degree=2, pi=Float64(pi), t=t_final), V)
+u_true = interpolate(Expression(u_str, degree=2, pi=Float64(pi), t=tspan[2]), V)
 
-alg = ImplicitEuler(autodiff=false)
-sol = OrdinaryDiffEq.solve(prob, alg)
+# some algorithms to try:
+# alg = ImplicitEuler(autodiff=false)
+# alg = Rosenbrock23(autodiff=false)
+# alg = Rodas5(autodiff=false)
+
+alg = KenCarp4(autodiff=false)
+sol = OrdinaryDiffEq.solve(prob, alg, reltol=1e-6, abstol=1e-6)
 
 vec_sol = get_array(p.u)
 vec_true = get_array(u_true)
-@test vec_sol ≈ vec_true rtol=1e-3
+@test vec_sol ≈ vec_true rtol=1e-2
 
 end#module


### PR DESCRIPTION
Here is the heat equation example talked about in #73. It is somewhat inaccurate:

![image](https://user-images.githubusercontent.com/7261506/64411043-abedd480-d08c-11e9-8f98-e2fa0248939c.png)

About 2.5% error. Also error does not get better if I use a finer grid.

@ChrisRackauckas you mentioned that passing a mass matrix might help, can you elaborate?

Code to create the plot:
```julia
@time include("examples/heat_equation.jl")
import PyPlot
import FEniCS
import .HeatEquationExample
Ex = HeatEquationExample
display(FEniCS.Plot(Ex.p.u))
display(FEniCS.Plot(Ex.u_true))
```