### PR TITLE
Extend mesh generation functions with cell type feature

### DIFF
--- a/src/FEniCS.jl
+++ b/src/FEniCS.jl
@@ -36,6 +36,8 @@ function __init__()
     global tetrahedron = fenics.tetrahedron
     global hexahedron = fenics.hexahedron #matplotlib cannot handle hexahedron elements
     global triangle = fenics.triangle
+    global quadrilateral = fenics.quadrilateral
+    global CellType = fenics.CellType
 end
 #the below code is an adaptation of aleadev.FEniCS.jl
 import Base: size, length, show, *, +, -,/, repr, div, sqrt,split,write

--- a/src/jfem.jl
+++ b/src/jfem.jl
@@ -307,7 +307,7 @@ mapping(self)
 """
 
 # some of these constant are initialized in __init__
-export hexahedron, tetrahedron, triangle
+export hexahedron, tetrahedron, quadrilateral, triangle
 
 family(finiteelement::FiniteElement) = fenicspycall(finiteelement, :family)
 

--- a/src/jfem.jl
+++ b/src/jfem.jl
@@ -46,7 +46,13 @@ Constant(x::Union{Real,Tuple}) = Expression(fenics.Constant(x, name="Constant($x
 export Constant
 
 @fenicsclass FeFunction
-FeFunction(V::FunctionSpace) = FeFunction(fenics.Function(V.pyobject))
+function FeFunction(V::FunctionSpace; name::String="")
+    if name == ""
+        return FeFunction(fenics.Function(V.pyobject))
+    else
+        return FeFunction(fenics.Function(V.pyobject, name=name))
+    end
+end
 assign(solution1::FeFunction,solution2 )=fenicspycall(solution1,:assign,solution2.pyobject)
 
 function assign(solution::FeFunction, data::AbstractArray)

--- a/src/jmesh.jl
+++ b/src/jmesh.jl
@@ -55,6 +55,9 @@ export cell_orientations,cells,hmin , hmax, init, init_global, coordinates, data
 domains, geometry,topology, num_cells,num_edges,num_entities,num_faces,num_facets,num_vertices, bounding_box_tree,
 rmax, rmin, size, ufl_cell , ufl_domain, ufl_id
 
+# This constant is initialized in __init__
+export CellType
+
 """
 Mesh(path::StringOrSymbol) \n
 Creates a Mesh based on a specified filename(path)
@@ -91,6 +94,7 @@ will be 2*nx*ny and the total number of vertices will be (nx + 1)*(ny + 1) \n
 diagonal ("left", "right", "right//left", "left//right", or "crossed") indicates the direction of the diagonals.
 """
 UnitSquareMesh(nx::Int, ny::Int, diagonal::StringOrSymbol="right") = Mesh(fenics.UnitSquareMesh(nx, ny, diagonal))
+UnitSquareMesh(nx::Int, ny::Int, cellType::PyObject) = Mesh(fenics.UnitSquareMesh.create(nx, ny, cellType))
 
 
 function UnitQuadMesh(nx::Int,ny::Int)
@@ -115,6 +119,7 @@ tetrahedra will be 6*nx*ny*nz and the total number of vertices will be (nx + 1)*
 
 """
 UnitCubeMesh(nx::Int, ny::Int, nz::Int) = Mesh(fenics.UnitCubeMesh(nx,ny,nz))
+UnitCubeMesh(nx::Int, ny::Int, nz::Int, cellType::PyObject) = Mesh(fenics.UnitCubeMesh.create(nx, ny, nz, cellType))
 """
 BoxMesh(p0, p1, nx::Int, ny::Int, nz::Int) \n
 
@@ -123,6 +128,7 @@ Given the number of cells (nx, ny, nz) in each direction, the total number of \n
 tetrahedra will be 6*nx*ny*nz and the total number of vertices will be (nx + 1)*(ny + 1)*(nz + 1).
 """
 BoxMesh(p0, p1, nx::Int, ny::Int, nz::Int)= Mesh(fenics.BoxMesh(p0,p1,nx,ny,nz))
+BoxMesh(p::NTuple{2, PyObject}, n::NTuple{3, Int}, cellType::PyObject) = Mesh(fenics.BoxMesh.create(p, n, cellType))
 
 """
 RectangleMesh(p0,p1,nx::Int,ny::Int,diagdir::StringOrSymbol="right") \n
@@ -132,6 +138,7 @@ of triangles will be 2*nx*ny and the total number of vertices will be (nx + 1)*(
 diagdir ("left", "right", "right/left", "left/right", or "crossed") indicates the direction of the diagonals.
 """
 RectangleMesh(p0,p1,nx::Int,ny::Int,diagdir::StringOrSymbol="right") = Mesh(fenics.RectangleMesh(p0,p1,nx,ny,diagdir))
+RectangleMesh(p::NTuple{2, PyObject}, n::NTuple{2, Int}, cellType::PyObject) = Mesh(fenics.RectangleMesh.create(p, n, cellType))
 
 """
 BoundaryMesh(mesh::Mesh,type_boundary::StringOrSymbol="exterior",order=true) \n


### PR DESCRIPTION
In FEniCS 2019.1 the convenience functions to construct simple meshes support a parameter to define the cell type (triangle and quadrilateral in 2D and tetrahedron and hexahedron in 3D). I have added similar support to the Julia wrapper. It is now possible to do:

    UnitSquareMesh(8, 8, CellType.Type.quadrilateral)
    RectangularMesh((Point((0, 0)), Point((1, 1)), (8, 8), CellType.Type.quadrilateral)
    UnitCubeMesh(8, 8, 8, CellType.Type.hexahedron)
    BoxMesh((Point((0, 0, 0)), Point((1, 1, 1)), (8, 8, 8), CellType.Type.hexahedron)

The `CellType.Type.[cellTypeName]` syntax is a bit clunky for my taste, but that is how it is done in FEniCS.py.