### PR TITLE
Change representation of FEniCS objects from str to repr

### DIFF
--- a/src/FEniCS.jl
+++ b/src/FEniCS.jl
@@ -76,7 +76,7 @@ set_log_level(lvl::Int) = fenics.set_log_level(lvl)
 
 str(obj::fenicsobject) = fenicspycall(obj, :__str__)
 repr(obj::fenicsobject) = fenicspycall(obj, :__repr__)
-show(io::IO, obj::fenicsobject) = show(io, str(obj))
+show(io::IO, obj::fenicsobject) = show(io, repr(obj))
 Docs.getdoc(obj::fenicsobject) = obj.pyobject.__doc__
 export str, repr
 


### PR DESCRIPTION
I noticed that some (as of yet unwrapped) FEniCS objects in Julia were showing up differently than in Python.

Julia:

    > using FEniCS
    > mesh = UnitSquareMesh(8, 8)
    > Expression(FEniCS.fenics.CellDiameter(mesh.pyobject))
    "diameter"

Python:

    > from fenics import *
    > mesh = UnitSquareMesh(8, 8)
    > CellDiameter(mesh)
    CellDiameter(Mesh(VectorElement(FiniteElement('Lagrange', triangle, 1), dim=2), 0))

This is due to:

    show(io::IO, obj::fenicsobject) = show(io, str(obj))

which can be fixed by changing it in to:

    show(io::IO, obj::fenicsobject) = show(io, repr(obj))