### PR TITLE
Fix assemble for cases where returned fenics form is reduced to a number

### DIFF
--- a/src/jfem.jl
+++ b/src/jfem.jl
@@ -170,6 +170,9 @@ export lhs, rhs
 #this assembles the matrix from a fenics form
 @fenicsclass Matrix
 
+# This handles the cases where a fenics form reduces to a number
+Matrix(a::T) where {T<:Real} = a
+
 assemble(assembly_item::Union{Form,Expression};tensor=nothing, form_compiler_parameters=nothing, add_values=false, finalize_tensor=true, keep_diagonal=false, backend=nothing) = Matrix(fenics.assemble(assembly_item.pyobject,
 tensor=tensor,form_compiler_parameters=form_compiler_parameters,add_values=add_values,finalize_tensor=finalize_tensor,keep_diagonal=keep_diagonal,backend=backend))
 export assemble


### PR DESCRIPTION
In Julia the `assemble` method calls `FEniCS.fenics.assemble` and wraps the returned object in a `FEniCS.Matrix`. `FEniCS.Matrix` accepts as single argument an object of type `PyCall.pyobject`. However, the return value of `FEniCS.fenics.assemble` is not always a `PyCall.pyobject`. It can be a float (maybe even an integer, but I have not encountered this yet). Currently, the `assemble` method fails in those cases:

```
using FEniCS

mesh = UnitSquareMesh(8, 8)
Q = FunctionSpace(mesh, "P", 1)

rho = FeFunction(Q)
rho_init = Expression("x[0]*(1 - x[0])*x[1]*(1 - x[1])", degree=1)
assign(rho, interpolate(rho_init, Q))

assemble(rho*dx)
ERROR: MethodError: no method matching FEniCS.Matrix(::Float64)
```

This pull request resolves this issue by adding an additional method:

    Matrix(a::T) where {T<:Real} = a

So in the cases where `FEniCS.fenics.assemble` returns something that is a subtype of `Real` the wrapping of the output into a `Matrix` object is mitigated.