### PR TITLE
Add wrapper for Cell class and assemble_local function

### DIFF
--- a/src/jfem.jl
+++ b/src/jfem.jl
@@ -177,6 +177,8 @@ assemble(assembly_item::Union{Form,Expression};tensor=nothing, form_compiler_par
 tensor=tensor,form_compiler_parameters=form_compiler_parameters,add_values=add_values,finalize_tensor=finalize_tensor,keep_diagonal=keep_diagonal,backend=backend))
 export assemble
 
+assemble_local(assembly_item::Union{Form,Expression}, cell::Cell) = fenics.assemble_local(assembly_item.pyobject, cell.pyobject)
+export assemble_local
 
 #I have changed this to Function+Form
 

--- a/src/jmesh.jl
+++ b/src/jmesh.jl
@@ -215,3 +215,17 @@ end
 
 export pyUnitTriangleMesh, pyUnitTetrahedronMesh, pyUnitSquareMesh, pyUnitQuadMesh,
 pyUnitIntervalMesh, pyUnitCubeMesh, pyBoxMesh, pyRectangleMesh,pyMesh, Point
+
+@fenicsclass Cell #https://fenicsproject.org/docs/dolfin/1.5.0/python/programmers-reference/cpp/mesh/Cell.html
+Cell(mesh::MeshImpl, i::Int) = Cell(fenics.Cell(mesh.pyobject, i))
+
+# Get coordinates of cell vertices
+get_vertex_coordinates(cell::Cell) = fenicspycall(cell, :get_vertex_coordinates)
+# Compute greatest distance between between two vertices of a cell
+h(cell::Cell) = fenicspycall(cell, :h)
+# Compute midpoint of a cell
+midpoint(cell::Cell) = fenicspycall(cell, :midpoint)
+# Compute volume of cell
+volume(cell::Cell) = fenicspycall(cell, :volume)
+
+export Cell, get_vertex_coordinates, h, midpoint, volume


### PR DESCRIPTION
This pull request adds a wrapper for the `Cell` class. I have already wrapped some of its attributes. The Cell class is needed when trying to assemble a Form in a single cell instead of in the entire mesh using the function `assemble_local`. This pull request also adds a wrapper for the `assemble_local` function. Here is an example:

```
using FEniCS

mesh = UnitSquareMesh(8, 8)
c = Cell(mesh, 0)

Q = FunctionSpace(mesh, "P", 1)
p = FeFunction(Q)
assign(p, Expression("x[0]+x[1]",  degree=1))

# Assemble Form in a single cell
assemble_local(p*dx, c)

# Coordinates of cell vertices
get_vertex_coordinates(c)

# Largest distance between vertices of cell
h(c)

# Coordinate of the cell mid-point
midpoint(c)

# Volume of cell
volume(c)
```